### PR TITLE
Fix a GdkPixbuf assertion warning

### DIFF
--- a/datagrid_gtk3/tests/test_datagrid-gtk3.py
+++ b/datagrid_gtk3/tests/test_datagrid-gtk3.py
@@ -449,7 +449,10 @@ class DataGridModelTest(unittest.TestCase):
 
             thumbnail.assert_called_once_with((123, 123), Image.BICUBIC)
             open_.assert_called_once_with('xxx')
-            self.assertEqual(add_border.call_count, 0)
+            # This is because of a PIL issue. See
+            # datagrid_gtk3.utils.transformations.image_transform for more
+            # details
+            self.assertEqual(add_border.call_count, 1)
             self.assertEqual(add_drop_shadow.call_count, 0)
 
     def _transform(self, transform_type, value):

--- a/datagrid_gtk3/tests/test_externals.py
+++ b/datagrid_gtk3/tests/test_externals.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""Test for external libs."""
+
+import base64
+import os
+import tempfile
+import unittest
+
+from PIL import Image
+
+from datagrid_gtk3.utils import imageutils
+
+_MEDIA_FILES = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)), os.pardir, "data", "media")
+_TEST_IMAGE_BASE64 = """
+AAABAAIAEBACAAEAAQCwAAAAJgAAACAgEAABAAQA6AIAANYAAAAoAAAAEAAAACAAAAABAAEAAAAA
+AEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP///wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABjDAAA
+UpAAAGMQAABSkAAAYwwAAAAAAAAAAAAAAAAAAAAAAAAAAAAA//8AAP//AAD//wAA//8AAP//AAAA
+AQAAAAEAAAABAAAAAQAAAAEAAAABAAAAAQAA//8AAP//AAD//wAA//8AACgAAAAgAAAAQAAAAAEA
+BAAAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAACAAAAAgIAAgAAAAIAAgACAgAAAgICA
+AMDAwAAAAP8AAP8AAAD//wD/AAAA/wD/AP//AAD///8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+AAAAAAAAAAAAAAAAAAAA//gAAAD/+AAAAHj/gAAAAPAHgAAA8AeAAAeHAHAAAADwB4AAAPAHgAAI
+cAAAAAAA+IgAAAD4iAAAD3AAAAAAAPAPAAAA8A8AAAiAAAAAAAD3iAAAAPeIAAAAiHeAAAAAiHAA
+AACIcAAAAAeIcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD/////////////////////////////////
+///////////////////////////////AEAQBwBAEAcAQBAHAEAQBwBAEAcAQBAHAEAQBwBAEAcAQ
+BAH//////////////////////////////////////////////////////////w==
+"""
+
+
+class PILTest(unittest.TestCase):
+
+    """Test for some PIL bugs."""
+
+    def test_thumbnail_no_bug(self):
+        """Test :meth:`PIL.thumbnail` without bugs."""
+        image = Image.open(
+            os.path.join(_MEDIA_FILES, 'icons', 'image.png'))
+        image.load()
+        self.assertEqual(image.size, (32, 32))
+
+        image.thumbnail((10, 10), Image.BICUBIC)
+
+        # This is a comparison with the test bellow in a file that doesn't fail
+        image_copy = image.copy()
+        self.assertEqual(image_copy.size, (10, 10))
+        pixbuf = imageutils.image2pixbuf(image)
+        self.assertEqual(
+            (pixbuf.get_width(), pixbuf.get_height()), (10, 10))
+
+    def test_thumbnail_bug_exists(self):
+        """Test for the existence of a bug on :meth:`PIL.thumbnail`."""
+        with tempfile.NamedTemporaryFile() as f:
+            # This image has something that breaks thumbnail propagation
+            f.write(base64.b64decode(_TEST_IMAGE_BASE64))
+            f.flush()
+
+            image = Image.open(f.name)
+            image.load()
+            self.assertEqual(image.size, (32, 32))
+
+            image.thumbnail((10, 10), Image.BICUBIC)
+
+            # When both those tests fail, it means we can remove fix the FIXME
+            # code on datagrid_gtk3.utils.transformations.image_transform.
+            # This should propagate the changes done by thumbnail
+            image_copy = image.copy()
+            self.assertEqual(image_copy.size, (32, 32))
+            pixbuf = imageutils.image2pixbuf(image)
+            self.assertEqual(
+                (pixbuf.get_width(), pixbuf.get_height()), (32, 32))
+
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/datagrid_gtk3/utils/transformations.py
+++ b/datagrid_gtk3/utils/transformations.py
@@ -416,6 +416,14 @@ def image_transform(path, size=24, fill_image=True, draw_border=False,
         size += border_size * 2
         size += shadow_size * 2
         size += shadow_offset
+    else:
+        # FIXME: There's a bug on PIL where image.thumbnail modifications will
+        # be lost for some images when saving it the way we do on image2pixbuf
+        # (even image.copy().size != image.size when it was resized).
+        # Adding a border of size 0 will make it at least be pasted to a new
+        # image (which didn't have its thumbnail method called), working around
+        # this issue.
+        image = imageutils.add_border(image, 0)
 
     pixbuf = imageutils.image2pixbuf(image)
     width = pixbuf.get_width()


### PR DESCRIPTION
There's a bug on PIL where image.thumbnail modifications will be lost when
saving it the way we do on image2pixbuf (even image.copy().size != image.size
when it was resized).

Adding a border of size 0 will make it at least be pasted to a new image
(which didn't have its thumbnail method called), working around this issue and
avoiding the assertion warning:

```
GdkPixbuf-CRITICAL **: gdk_pixbuf_copy_area: assertion
    'dest_x >= 0 && dest_x + width <= dest_pixbuf->width' failed
```
