### PR TITLE
Custom transformer options

### DIFF
--- a/datagrid_gtk3/ui/grid.py
+++ b/datagrid_gtk3/ui/grid.py
@@ -1758,11 +1758,14 @@ class DataGridModel(GenericTreeModel):
             ))
 
         if self.data_source.config:
-            custom_options = self.data_source.config[column_index].get(
-                'encoding_options'
-            )
-            if custom_options:
-                transformer_kwargs['options'] = custom_options
+            try:
+                custom_options = self.data_source.config[column_index].get(
+                    'encoding_options'
+                )
+                if custom_options:
+                    transformer_kwargs['options'] = custom_options
+            except IndexError:
+                pass  # No config for `column_index`
 
         return transformer(value, **transformer_kwargs)
 

--- a/datagrid_gtk3/utils/transformations.py
+++ b/datagrid_gtk3/utils/transformations.py
@@ -62,6 +62,15 @@ def register_transformer(transformer_name, transformer):
     _transformers[transformer_name] = transformer
 
 
+def unregister_transformer(transformer_name):
+    """Unregister a transformer.
+
+    :param str transformer_name: the name to register the transformer
+    :raise KeyError: if a transformer is not registered under the given name
+    """
+    del _transformers[transformer_name]
+
+
 def transformer(transformer_name):
     """A decorator to easily register a decorator.
 


### PR DESCRIPTION
Data source column configuration can contain an `encoding_options`
field. The value of this field will be passes as an 'options'
argument to the transformer specified for that column.
