### PR TITLE
Treat flat loading of tree data like list

### DIFF
--- a/datagrid_gtk3/db/sqlite.py
+++ b/datagrid_gtk3/db/sqlite.py
@@ -161,10 +161,6 @@ class SQLiteDataSource(DataSource):
 
         # OFFSET
         page = params.get('page', 0)
-        # FIXME: If we have a PARENT_ID_COLUMN, all results
-        # were loaded on first load. How to handle this better?
-        if page > 0 and self.PARENT_ID_COLUMN is not None:
-            return rows
         offset = page * self.MAX_RECS
         # A little optimization to avoid doing more queries when we
         # already loaded everything

--- a/datagrid_gtk3/ui/grid.py
+++ b/datagrid_gtk3/ui/grid.py
@@ -1639,8 +1639,11 @@ class DataGridModel(GenericTreeModel):
         :return: True if update took place, False if not
         :rtype: bool
         """
-        # When the data is hierarchical, all the root data was already loaded
-        if parent_node is None and self.parent_column_idx is not None:
+        is_tree = (self.parent_column_idx is not None and
+                   not self.active_params.get('flat', False))
+        # When the data is hierarchical, all the root data was already loaded,
+        # except in a flat view, where data is being lazy loaded.
+        if is_tree and parent_node is None:
             return False
 
         if parent_node is None:
@@ -1667,7 +1670,7 @@ class DataGridModel(GenericTreeModel):
             # FIXME: Non-hierarchical data need this to display the new row,
             # but hierarchical ones not only will work without this, but will
             # produce warnings if we try to call this for them.
-            if self.parent_column_idx is None:
+            if not is_tree:
                 path = Gtk.TreePath(row.path)
                 self.row_inserted(path, self.get_iter(path))
 


### PR DESCRIPTION
The only moment where we will not load more rows when scrolling to the
bottom is for hierarchical data loading as a tree.

If we have an hierarchical data, but it is being loaded in flat view, it is
actually a list and should be lazy loaded as such.

Fix https://github.com/viaforensics/viaextract-main/issues/1337
