### PR TITLE
add encoding_options to columns data to avoid issues

### DIFF
--- a/datagrid_gtk3/db/sqlite.py
+++ b/datagrid_gtk3/db/sqlite.py
@@ -478,6 +478,7 @@ class SQLiteDataSource(DataSource):
                         data_type = self.STRING_PY_TYPES[
                             self.config[counter]['type']]
                         transform = self.config[counter].get('encoding', None)
+                        options = self.config[counter].get('encoding_options', None)
                         expand = self.config[counter].get('expand', False)
                         visible = self.config[counter].get('visible', True)
                         counter += 1
@@ -486,6 +487,7 @@ class SQLiteDataSource(DataSource):
                         data_type = self.SQLITE_PY_TYPES.get(
                             row[2].upper(), str)
                         transform = None  # TODO: eg. buffer
+                        options = None
                         expand = False
                         visible = True
 
@@ -494,6 +496,7 @@ class SQLiteDataSource(DataSource):
                         'display': display_name,
                         'type': data_type,
                         'transform': transform,
+                        'transform_options': options,
                         'expand': expand,
                         'visible': visible,
                     }
@@ -524,6 +527,7 @@ class SQLiteDataSource(DataSource):
                         'display': '__selected',
                         'type': int,
                         'transform': 'boolean',
+                        'transform_options': 'boolean',
                         'expand': False,
                         'visible': True,
                     }

--- a/datagrid_gtk3/ui/grid.py
+++ b/datagrid_gtk3/ui/grid.py
@@ -1773,15 +1773,9 @@ class DataGridModel(GenericTreeModel):
                 decode_fallback=self.decode_fallback,
             ))
 
-        if self.data_source.config:
-            try:
-                custom_options = self.data_source.config[column_index].get(
-                    'encoding_options'
-                )
-                if custom_options:
-                    transformer_kwargs['options'] = custom_options
-            except IndexError:
-                pass  # No config for `column_index`
+        custom_options = col_dict['transform_options']
+        if custom_options:
+            transformer_kwargs['options'] = custom_options
 
         return transformer(value, **transformer_kwargs)
 


### PR DESCRIPTION
When using json transform, I noticed `self.data_source.config[column_index]` was not ignoring `__selected` or `__viaextract_id` columns, so we were getting encoding options for incorrect columns. 

This PR adds the options to the columns dict so we can get the options from the same location as the transform details.
