### PR TITLE
Remove expand

### DIFF
--- a/datagrid_gtk3/ui/glade/datagrid.glade
+++ b/datagrid_gtk3/ui/glade/datagrid.glade
@@ -48,32 +48,6 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkButton" id="expand_all_btn">
-                        <property name="label" translatable="yes">▶</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">True</property>
-                        <property name="tooltip_text" translatable="yes">Expand all rows</property>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">1</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkButton" id="collapse_all_btn">
-                        <property name="label" translatable="yes">▼</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">True</property>
-                        <property name="tooltip_text" translatable="yes">Collapse all rows</property>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">2</property>
-                      </packing>
-                    </child>
-                    <child>
                       <object class="GtkSeparator" id="vseparator1">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
@@ -83,7 +57,7 @@
                         <property name="expand">False</property>
                         <property name="fill">True</property>
                         <property name="padding">3</property>
-                        <property name="position">3</property>
+                        <property name="position">2</property>
                       </packing>
                     </child>
                     <child>
@@ -97,7 +71,7 @@
                       <packing>
                         <property name="expand">False</property>
                         <property name="fill">True</property>
-                        <property name="position">4</property>
+                        <property name="position">3</property>
                       </packing>
                     </child>
                     <child>
@@ -110,7 +84,7 @@
                         <property name="expand">False</property>
                         <property name="fill">True</property>
                         <property name="padding">3</property>
-                        <property name="position">6</property>
+                        <property name="position">4</property>
                       </packing>
                     </child>
                     <child>
@@ -122,7 +96,7 @@
                         <property name="expand">True</property>
                         <property name="fill">True</property>
                         <property name="padding">3</property>
-                        <property name="position">7</property>
+                        <property name="position">5</property>
                       </packing>
                     </child>
                     <child>
@@ -135,7 +109,7 @@
                         <property name="expand">False</property>
                         <property name="fill">False</property>
                         <property name="padding">2</property>
-                        <property name="position">8</property>
+                        <property name="position">6</property>
                       </packing>
                     </child>
                     <child>
@@ -153,7 +127,7 @@
                       <packing>
                         <property name="expand">False</property>
                         <property name="fill">True</property>
-                        <property name="position">9</property>
+                        <property name="position">7</property>
                       </packing>
                     </child>
                     <child>
@@ -166,7 +140,7 @@
                         <property name="expand">False</property>
                         <property name="fill">True</property>
                         <property name="padding">2</property>
-                        <property name="position">10</property>
+                        <property name="position">8</property>
                       </packing>
                     </child>
                     <child>
@@ -179,7 +153,7 @@
                         <property name="expand">False</property>
                         <property name="fill">False</property>
                         <property name="padding">2</property>
-                        <property name="position">11</property>
+                        <property name="position">9</property>
                       </packing>
                     </child>
                     <child>
@@ -197,7 +171,7 @@
                       <packing>
                         <property name="expand">False</property>
                         <property name="fill">True</property>
-                        <property name="position">12</property>
+                        <property name="position">10</property>
                       </packing>
                     </child>
                     <child>
@@ -210,7 +184,7 @@
                         <property name="expand">False</property>
                         <property name="fill">True</property>
                         <property name="padding">3</property>
-                        <property name="position">13</property>
+                        <property name="position">11</property>
                       </packing>
                     </child>
                     <child>
@@ -224,7 +198,7 @@
                       <packing>
                         <property name="expand">True</property>
                         <property name="fill">True</property>
-                        <property name="position">14</property>
+                        <property name="position">12</property>
                       </packing>
                     </child>
                     <child>
@@ -237,7 +211,7 @@
                       <packing>
                         <property name="expand">True</property>
                         <property name="fill">True</property>
-                        <property name="position">15</property>
+                        <property name="position">13</property>
                       </packing>
                     </child>
                   </object>


### PR DESCRIPTION
- Forget expanded ids when changing views: When changing treeview to flat view, if we don't forget the expanded ids, it would try to expand eveything again which would result in the whole data source being loaded.
- Remove expand/collapse all buttons: This is an operation that can sometimes freeze the UI and doesn't make too much sense and its functionality is almost the same as using the flat view.

Both commits were taken away from #49 so they can be merged soon and also make it easier to review.
