### PR TITLE
Set the first column as the id

### DIFF
--- a/datagrid_gtk3/ui/grid.py
+++ b/datagrid_gtk3/ui/grid.py
@@ -554,6 +554,7 @@ class DataGridController(object):
         combo.pack_start(renderer, True)
         combo.add_attribute(renderer, 'text', 0)
         combo.set_active(0)
+        combo.set_id_column(0)
 
         combo.connect('changed', self.on_filter_changed, attr)
 


### PR DESCRIPTION
Make it possible for someone to select the active row for
custom filters using the first column of the combobox' model.

Related to https://github.com/viaforensics/viaextract-main/issues/551 but since it is a very simple change and doesn't affect anything else, can be safely merged earlier.