### PR TITLE
Use _rowid_ when the table doesn't have a pk

### DIFF
--- a/datagrid_gtk3/tests/test_datagrid-gtk3.py
+++ b/datagrid_gtk3/tests/test_datagrid-gtk3.py
@@ -356,7 +356,7 @@ class TransformationsTest(unittest.TestCase):
         self.datagrid_model = DataGridModel(
             data_source=SQLiteDataSource(
                 '', 'test',
-                ensure_selected_column=False, ensure_primary_key=False),
+                ensure_selected_column=False),
             get_media_callback=mock.MagicMock(),
             decode_fallback=mock.MagicMock()
         )


### PR DESCRIPTION
Instead of having to create a new table to add a new pk when the
table doesn't have one, lets just use the sqlite built-in unique
identifier accessible by '_rowid_'.

@drippsj this should probably fix that issue for you.

There's one more issue that you might encounter because of this like https://github.com/viaforensics/viaextract-main/blob/develop/viaextract/ui/preview/base.py#L582.

On that db you provided me, there are some bool cols with `70` as a value. That makes those asserts fail and not open the preview.

I'm wondering if we should change those asserts to warnings...