### PR TITLE
Don't assume __selected is always on position 0

### DIFF
--- a/datagrid_gtk3/db/__init__.py
+++ b/datagrid_gtk3/db/__init__.py
@@ -44,6 +44,7 @@ class DataSource(object):
     """Base class for data sources."""
 
     ID_COLUMN = 'rowid'
+    SELECTED_COLUMN = '__selected'
     PARENT_ID_COLUMN = None
     CHILDREN_LEN_COLUMN = None
     FLAT_COLUMN = None
@@ -56,6 +57,7 @@ class DataSource(object):
         self.parent_column_idx = None
         self.children_len_column_idx = None
         self.flat_column_idx = None
+        self.selected_column_idx = None
 
     def get_visible_columns(self):
         return []

--- a/datagrid_gtk3/tests/test_datagrid-gtk3.py
+++ b/datagrid_gtk3/tests/test_datagrid-gtk3.py
@@ -112,7 +112,7 @@ class DataGridControllerTest(unittest.TestCase):
             scrolledwindow.get_child(), icon_view)
         self.assertEqual(self.model.image_max_size, 100.0)
         self.assertTrue(self.model.image_draw_border)
-        self.assertEqual(icon_view.pixbuf_column, 6)
+        self.assertEqual(icon_view.pixbuf_column, 5)
 
         # TreeView
         self.datagrid_controller.options_popup.emit(

--- a/datagrid_gtk3/tests/test_sqlite.py
+++ b/datagrid_gtk3/tests/test_sqlite.py
@@ -51,7 +51,7 @@ class SQLiteDataSourceTest(unittest.TestCase):
         }
         rows = self.datasource.load(param)
         self.assertEqual(len(rows), 2)
-        self.assertEqual(rows[0].data[3], 'Goldman')
+        self.assertEqual(rows[0].data[2], 'Goldman')
 
     def test_load_with_where_param(self):
         """Filter results with a search param."""
@@ -66,21 +66,21 @@ class SQLiteDataSourceTest(unittest.TestCase):
         self.assertEqual(len(rows), 2)
         self.assertEqual(
             {('Oscar', 'Goldman'), ('Monica', 'Goldman')},
-            {(row.data[2], row.data[3]) for row in rows})
+            {(row.data[1], row.data[2]) for row in rows})
 
     def test_load_paging(self):
         """Load first and second pages of records."""
         self.datasource.load()  # initial load is always without paging
         rows = self.datasource.load({'page': 1})
         self.assertEqual(len(rows), 2)
-        self.assertEqual(rows[0].data[3], 'Goldman')
+        self.assertEqual(rows[0].data[2], 'Goldman')
 
     def test_update(self):
         """Update __selected in first record in data set."""
         self.datasource.update({'__selected': True}, [1])
         # ^^ update row with id 1
         rows = self.datasource.load()
-        self.assertEqual(rows[0].data[1], 1)
+        self.assertEqual(rows[0].data[0], 1)
 
     def test_get_all_record_ids(self):
         """Get all record ids for a particular query."""
@@ -102,9 +102,9 @@ class SQLiteDataSourceTest(unittest.TestCase):
     def test_get_single_record(self):
         """Retrieve a single record as a tuple of values."""
         row = self.datasource.get_single_record(1)
-        self.assertEqual(row[1], 1)
-        self.assertEqual(row[2], 'Dee')
-        self.assertEqual(row[3], 'Timberlake')
+        self.assertEqual(row[0], 1)
+        self.assertEqual(row[1], 'Dee')
+        self.assertEqual(row[2], 'Timberlake')
 
     def test_select(self):
         """Get data without class instance or paging."""

--- a/datagrid_gtk3/ui/grid.py
+++ b/datagrid_gtk3/ui/grid.py
@@ -1542,7 +1542,7 @@ class DataGridIconView(Gtk.IconView):
         # https://git.gnome.org/browse/gtk+/tree/gtk/gtkiconview.c
         # Atm we will avoid row-changed and just call queue_redraw which
         # will be a lot faster! We should try to find a better solution
-        self.model.set_value(iter_, selected_column_idx, not val,
+        self.model.set_value(iter_, selected_idx, not val,
                              emit_event=False)
         self.queue_draw()
 


### PR DESCRIPTION
Remove some hardcoded '__selected' and position '0' from the code.

Also, we can remove the workaround where we would have to sum 1
on every column index in case __selected was added. This was
being done wrong when __selected was found before any of
those other columns (id, parent, flat, etc).

~~obs. I still need to fix the the test cases.~~

@drippsj does this fix the issue for you?