### PR TITLE
Degree decimal str transformer should return string

### DIFF
--- a/datagrid_gtk3/tests/utils/test_transformations.py
+++ b/datagrid_gtk3/tests/utils/test_transformations.py
@@ -30,9 +30,9 @@ class DegreeDecimalStrTransformTest(unittest.TestCase):
         """Decimal point is inserted in the expected location."""
         self.assertEqual(
             degree_decimal_str_transform('12345678'),
-            12.345678,
+            '12.345678',
         )
         self.assertEqual(
             degree_decimal_str_transform('123456'),
-            0.123456,
+            '0.123456',
         )

--- a/datagrid_gtk3/tests/utils/test_transformations.py
+++ b/datagrid_gtk3/tests/utils/test_transformations.py
@@ -33,6 +33,14 @@ class DegreeDecimalStrTransformTest(unittest.TestCase):
             '12.345678',
         )
         self.assertEqual(
+            degree_decimal_str_transform('1234567'),
+            '1.234567',
+        )
+        self.assertEqual(
             degree_decimal_str_transform('123456'),
             '0.123456',
+        )
+        self.assertEqual(
+            degree_decimal_str_transform('12345'),
+            '0.012345',
         )

--- a/datagrid_gtk3/utils/transformations.py
+++ b/datagrid_gtk3/utils/transformations.py
@@ -449,4 +449,4 @@ def degree_decimal_str_transform(value, length=8):
         value = '0' * (length - len(value)) + value
 
     value = '{}.{}'.format(value[:2], value[2:])
-    return float(value)
+    return value

--- a/datagrid_gtk3/utils/transformations.py
+++ b/datagrid_gtk3/utils/transformations.py
@@ -446,8 +446,7 @@ def degree_decimal_str_transform(value, length=8):
     assert value.isdigit(), 'All characters expected to be digits'
     assert len(value) <= length, \
         'String length expected to be {} or less'.format(length)
-    if len(value) < length:
-        value = '0' * (length - len(value)) + value
+    value = value.zfill(length)
 
     # Add decimal point at the expected location
     value = '{}.{}'.format(value[:2], value[2:])

--- a/datagrid_gtk3/utils/transformations.py
+++ b/datagrid_gtk3/utils/transformations.py
@@ -3,7 +3,8 @@
 import datetime
 import logging
 import HTMLParser
-import re
+
+from decimal import Decimal
 
 import dateutil.parser
 from gi.repository import Gtk
@@ -452,5 +453,5 @@ def degree_decimal_str_transform(value, length=8):
     value = '{}.{}'.format(value[:2], value[2:])
 
     # Remove non-significant leading zeroes
-    value = re.sub(r'0+(\d\.)', r'\1', value)
-    return value
+    value = Decimal(value)
+    return str(value)

--- a/datagrid_gtk3/utils/transformations.py
+++ b/datagrid_gtk3/utils/transformations.py
@@ -3,6 +3,7 @@
 import datetime
 import logging
 import HTMLParser
+import re
 
 import dateutil.parser
 from gi.repository import Gtk
@@ -448,5 +449,9 @@ def degree_decimal_str_transform(value, length=8):
     if len(value) < length:
         value = '0' * (length - len(value)) + value
 
+    # Add decimal point at the expected location
     value = '{}.{}'.format(value[:2], value[2:])
+
+    # Remove non-significant leading zeroes
+    value = re.sub(r'0+(\d\.)', r'\1', value)
     return value


### PR DESCRIPTION
The `degree_decimal_str` transformer I added a few days ago doesn't seem to be working as expected. The problem is that it seems there's convention in the transformers to return strings, since that makes easier to interact with gtk widgets.

This PR updates the transformer to return a string and be more consistent with the other ones.  