### PR TITLE
Only set `_is_checked` if the model has a selected column

### DIFF
--- a/datagrid_gtk3/ui/grid.py
+++ b/datagrid_gtk3/ui/grid.py
@@ -1377,8 +1377,9 @@ class DataGridCellAreaRenderer(Gtk.CellAreaBox):
         """
         # For some reason, can't use super here
         Gtk.CellAreaBox.do_apply_attributes(self, model, iter_, *args)
-        self._is_checked = model.get_value(
-            iter_, model.data_source.selected_column_idx)
+        if model.data_source.selected_column_idx:
+            self._is_checked = model.get_value(
+                iter_, model.data_source.selected_column_idx)
 
 
 class DataGridIconView(Gtk.IconView):


### PR DESCRIPTION
This was being maskareted before when we assumed that the column idx 0
was the selected one, but now when we don't have a selected column,
`selected_column_idx` will be `None`.