### PR TITLE
Return placeholder if image fails and no thread

### DIFF
--- a/datagrid_gtk3/utils/imageutils.py
+++ b/datagrid_gtk3/utils/imageutils.py
@@ -286,10 +286,11 @@ class ImageCacheManager(GObject.GObject):
             # load it on a thread
             if not load_on_thread:
                 pixbuf = self._transform_image(*params)
-                self._cache_pixbuf(params, pixbuf)
-                return pixbuf
-
-            if params not in self._waiting:
+                # If no pixbuf, let the fallback image be returned
+                if pixbuf:
+                    self._cache_pixbuf(params, pixbuf)
+                    return pixbuf
+            elif params not in self._waiting:
                 self._waiting.add(params)
                 self._queue.put(params)
 


### PR DESCRIPTION
Discovered this issue when looking at the `path` column on the reporting carved data.