### PR TITLE
Do a numeric ordering if string is a number

### DIFF
--- a/datagrid_gtk3/db/sqlite.py
+++ b/datagrid_gtk3/db/sqlite.py
@@ -183,9 +183,13 @@ class SQLiteDataSource(DataSource):
 
         # ORDER BY
         order_by = params.get('order_by', None)
-        order_by = order_by and collate(self.table.columns[order_by], 'NOCASE')
+        # Do a numeric ordering first, as suggested here
+        # (http://stackoverflow.com/a/4204641), and then a case-insensitive one
+        order_by = (order_by and
+                    [self.table.columns[order_by] + 0,
+                     collate(self.table.columns[order_by], 'NOCASE')])
         if order_by is not None and params.get('desc', False):
-            order_by = desc(order_by)
+            order_by = [desc(col) for col in order_by]
 
         # OFFSET
         page = params.get('page', 0)


### PR DESCRIPTION
If the string is a number, this will make sure that strings like '3' comes
before '25. For strings that are not a numbers, the default case-insensitive
ordering will still work just like before.

Fix https://github.com/viaforensics/viaextract-main/issues/1673