### PR TITLE
Update view when data_source changes

### DIFF
--- a/datagrid_gtk3/db/__init__.py
+++ b/datagrid_gtk3/db/__init__.py
@@ -83,3 +83,7 @@ class DataSource(GObject.GObject):
 
 class EmptyDataSource(DataSource):
     """Data source that can be used when an empty data grid is required."""
+
+    __gsignals__ = {
+        'rows-changed': (GObject.SignalFlags.RUN_LAST, None, (object, object)),
+    }

--- a/datagrid_gtk3/db/__init__.py
+++ b/datagrid_gtk3/db/__init__.py
@@ -5,6 +5,8 @@ backends (eg. SQLite)
 
 """
 
+from gi.repository import GObject
+
 
 class Node(list):
 
@@ -40,7 +42,7 @@ class Node(list):
         return loaded
 
 
-class DataSource(object):
+class DataSource(GObject.GObject):
     """Base class for data sources."""
 
     ID_COLUMN = 'rowid'
@@ -50,6 +52,7 @@ class DataSource(object):
     FLAT_COLUMN = None
 
     def __init__(self):
+        super(DataSource, self).__init__()
         self.columns = []
         self.total_recs = 0
         self.display_all = True

--- a/datagrid_gtk3/db/sqlite.py
+++ b/datagrid_gtk3/db/sqlite.py
@@ -282,6 +282,11 @@ class SQLiteDataSource(DataSource):
                     cursor.execute(sql)
                 conn.commit()
 
+        # Emit rows-changed for any other databases connected to the same
+        # database and table. This is to allow any view using them
+        # to update themselves with the changes done here.
+        # The current object will not emit the event as it is the one who
+        # made the update and thus, is assumed to know about the changes
         for db in self.__class__._DBS:
             if db is self:
                 continue

--- a/datagrid_gtk3/db/sqlite.py
+++ b/datagrid_gtk3/db/sqlite.py
@@ -81,7 +81,7 @@ class SQLiteDataSource(DataSource):
         'rows-changed': (GObject.SignalFlags.RUN_LAST, None, (object, object)),
     }
 
-    _DBS = weakref.WeakValueDictionary()
+    _DBS = weakref.WeakSet()
 
     MAX_RECS = 100
     SQLITE_PY_TYPES = {
@@ -154,7 +154,7 @@ class SQLiteDataSource(DataSource):
                                    'RENAME TO __visible_columns')
                     conn.commit()
 
-        self.__class__._DBS[(db_file, self.table.name, id(self))] = self
+        self.__class__._DBS.add(self)
 
     ###
     # Public
@@ -282,10 +282,10 @@ class SQLiteDataSource(DataSource):
                     cursor.execute(sql)
                 conn.commit()
 
-        for (db_file, table_name, id_), db in self.__class__._DBS.items():
+        for db in self.__class__._DBS:
             if db is self:
                 continue
-            if (db_file, table_name) != (self.db_file, self.table.name):
+            if (db.db_file, db.table.name) != (self.db_file, self.table.name):
                 continue
 
             db.emit('rows-changed', params, ids)


### PR DESCRIPTION
Track existing datasources and, if they are accessing the same db and
table, emit a signal so datagrid (and the object using the other instance)
can update their views when the value of a row changes.

This is needed for the conversation view changes on https://github.com/viaforensics/viaextract-main/pull/1726