### PR TITLE
Remove non-printable characters from string

### DIFF
--- a/datagrid_gtk3/tests/utils/test_stringutils.py
+++ b/datagrid_gtk3/tests/utils/test_stringutils.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+
+"""String utilities test cases."""
+
+import string
+import unittest
+
+from datagrid_gtk3.utils.stringutils import (
+    is_printable,
+    strip_non_printable,
+)
+
+
+class StringUtilsTest(unittest.TestCase):
+
+    """Tests for :mod:`datagrid.utils.stringutils`."""
+
+    def test_printable(self):
+        """Tests for :func:`datagrid.utils.stringutils.is_printable`."""
+        for char in ['a', 'Z', '?', '\n']:
+            self.assertTrue(is_printable(char))
+
+        for char in string.whitespace:
+            self.assertTrue(is_printable(char))
+
+        # UTF-8 encoded non-ascii characters should be considered printable
+        for char in u'žćčđš'.encode('utf-8'):
+            self.assertTrue(is_printable(char))
+
+        for char in [chr(0), chr(20), chr(30)]:
+            self.assertFalse(is_printable(char))
+
+    def test_strip_non_printable(self):
+        """Tests for :func:`datagrid.utils.stringutils.strip_non_printable`."""
+        self.assertEqual(
+            strip_non_printable(
+                "Some string\nWith\tsome %s non-printable, %s chars" % (
+                    chr(20), chr(30))),
+            "Some string\nWith\tsome  non-printable,  chars")
+
+        self.assertEqual(
+            strip_non_printable(
+                u"Ração %s para %s búfalos" % (chr(20), chr(30))),
+            u"Ração  para  búfalos")

--- a/datagrid_gtk3/utils/stringutils.py
+++ b/datagrid_gtk3/utils/stringutils.py
@@ -1,0 +1,24 @@
+"""String utilities."""
+
+
+def is_printable(char):
+    """Determines whether a character can be displayed directly.
+
+    Used for testing if some content should be treated as text or binary.
+
+    :param char: Character to be tested
+    :type char: str
+    :rtype: bool
+    """
+    char_code = ord(char)
+    return (char_code >= 32) or (9 <= char_code <= 13)
+
+
+def strip_non_printable(string_):
+    """Remove non-printable characters from the string.
+
+    :param string_: The string to remove the characters from
+    :type string_: str
+    :rtype: str
+    """
+    return ''.join(c for c in string_ if is_printable(c))

--- a/datagrid_gtk3/utils/transformations.py
+++ b/datagrid_gtk3/utils/transformations.py
@@ -2,6 +2,7 @@
 
 import datetime
 import logging
+import string
 import HTMLParser
 
 from decimal import Decimal
@@ -104,6 +105,12 @@ def string_transform(value, max_length=None, oneline=True,
             if decode_fallback is None:
                 raise
             value = decode_fallback(value)
+
+    # Remove non-printable caracteres from the string. Only keep those
+    # considered as whitespace/newline. We cannot use string.printable
+    # here as it would remove unicode caracteres too.
+    value = u''.join(c for c in value
+                     if ord(c) >= 32 or c in string.whitespace)
 
     if oneline:
         value = u' '.join(v.strip() for v in value.splitlines() if v.strip())

--- a/datagrid_gtk3/utils/transformations.py
+++ b/datagrid_gtk3/utils/transformations.py
@@ -2,7 +2,6 @@
 
 import datetime
 import logging
-import string
 import HTMLParser
 
 from decimal import Decimal
@@ -12,6 +11,7 @@ from gi.repository import Gtk
 
 from datagrid_gtk3.utils import imageutils
 from datagrid_gtk3.utils import dateutils
+from datagrid_gtk3.utils import stringutils
 
 logger = logging.getLogger(__name__)
 _transformers = {}
@@ -106,11 +106,10 @@ def string_transform(value, max_length=None, oneline=True,
                 raise
             value = decode_fallback(value)
 
-    # Remove non-printable caracteres from the string. Only keep those
+    # Remove non-printable characters from the string. Only keep those
     # considered as whitespace/newline. We cannot use string.printable
-    # here as it would remove unicode caracteres too.
-    value = u''.join(c for c in value
-                     if ord(c) >= 32 or c in string.whitespace)
+    # here as it would remove unicode characters too.
+    value = stringutils.strip_non_printable(value)
 
     if oneline:
         value = u' '.join(v.strip() for v in value.splitlines() if v.strip())


### PR DESCRIPTION
Remove non-printable caracteres from the string. Keep only those considered as whitespace/newline

Fix https://github.com/viaforensics/viaextract-main/issues/1739

@tomanderson2 this is a generic fix that should fix your issue (if the problem is really what you said, regarding the non-printable characteres). I don't have any data with that problem so I cannot reproduce it. If it doesn't fix, I'll really need the `recovered.db` to analyse and create a better fix.