### PR TITLE
Allow to filter down to the time of the day

### DIFF
--- a/datagrid_gtk3/ui/glade/popupcal.glade
+++ b/datagrid_gtk3/ui/glade/popupcal.glade
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.16.1 -->
+<interface>
+  <requires lib="gtk+" version="3.10"/>
+  <object class="GtkAdjustment" id="hours_adjustment">
+    <property name="upper">23</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
+  </object>
+  <object class="GtkAdjustment" id="minutes_adjustment">
+    <property name="upper">59</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
+  </object>
+  <object class="GtkWindow" id="date_picker_window">
+    <property name="can_focus">False</property>
+    <child>
+      <object class="GtkAlignment" id="date_picker_alignment">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="top_padding">5</property>
+        <property name="bottom_padding">5</property>
+        <property name="left_padding">5</property>
+        <property name="right_padding">5</property>
+        <child>
+          <object class="GtkBox" id="box1">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="spacing">5</property>
+            <property name="homogeneous">True</property>
+            <child>
+              <object class="GtkCalendar" id="calendar">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="year">2015</property>
+                <property name="month">7</property>
+                <property name="day">18</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox" id="box2">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="orientation">vertical</property>
+                <child>
+                  <object class="GtkBox" id="box3">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="spacing">5</property>
+                    <child>
+                      <object class="GtkLabel" id="label3">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkSpinButton" id="hours">
+                        <property name="width_request">75</property>
+                        <property name="height_request">100</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="max_length">2</property>
+                        <property name="width_chars">2</property>
+                        <property name="text" translatable="yes">00</property>
+                        <property name="xalign">0.5</property>
+                        <property name="input_purpose">number</property>
+                        <property name="orientation">vertical</property>
+                        <property name="adjustment">hours_adjustment</property>
+                        <property name="numeric">True</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="label2">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">:</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkSpinButton" id="minutes">
+                        <property name="width_request">75</property>
+                        <property name="height_request">100</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="max_length">2</property>
+                        <property name="width_chars">2</property>
+                        <property name="text" translatable="yes">00</property>
+                        <property name="xalign">0.5</property>
+                        <property name="input_purpose">number</property>
+                        <property name="orientation">vertical</property>
+                        <property name="adjustment">minutes_adjustment</property>
+                        <property name="numeric">True</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">3</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="label4">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">4</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">False</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+  </object>
+</interface>

--- a/datagrid_gtk3/utils/dateutils.py
+++ b/datagrid_gtk3/utils/dateutils.py
@@ -3,6 +3,8 @@
 import datetime
 import logging
 
+import dateutil.parser
+
 logger = logging.getLogger(__name__)
 __all__ = ('supported_timestamp_formats', 'normalize_timestamp')
 
@@ -62,6 +64,11 @@ _normalizations = dict(
 )
 
 
+class InvalidDateFormat(Exception):
+
+    """Invalid date format exception."""
+
+
 def supported_timestamp_formats():
     """Get a list of supported timestamp formats.
 
@@ -96,3 +103,19 @@ def normalize_timestamp(value, timestamp_format, inverse=False):
 
     pos = _NORM_INV_POS if inverse else _NORM_POS
     return _normalizations[timestamp_format][pos](value)
+
+
+def parse_string(string):
+    """Parse the string to a datetime object.
+
+    :param str string: The string to parse
+    :rtype: `datetime.datetime`
+    :raises: :exc:`InvalidDateFormat` when date format is invalid
+    """
+    try:
+        # Try to parse string as a date
+        value = dateutil.parser.parse(string)
+    except (OverflowError, TypeError, ValueError):
+        raise InvalidDateFormat("Invalid date format %r" % (string, ))
+
+    return value


### PR DESCRIPTION
Change DateEntry so it allows to filter down to the time of the day. Also rewrite the DateEntry code/api to make its code easier to read/understand/use.

Those changes are mostly for the conversation view, but we can let them enabled for datagrid also if you guys prefer. The only downside is that each entry uses more space.

If you prefer to let it out of the datagrid, I can add a parameter to it to avoid displaying/using the data related to the hours/seconds and only make it visible on the conversation view itself.

I still need to add some tests, specially to the code I moved to `dateutils` module.