### PR TITLE
Don't get the repr for strings starting with \x00

### DIFF
--- a/datagrid_gtk3/utils/transformations.py
+++ b/datagrid_gtk3/utils/transformations.py
@@ -90,13 +90,6 @@ def string_transform(value, max_length=None, oneline=True,
         return '<NULL>'
 
     if isinstance(value, str):
-        # FIXME GTK3: On gtk2, set_text would raise TypeError when
-        # trying to set_text with a string containing a null (\x00)
-        # character. gtk3 will allow that, but if the null character is
-        # at the beginning of it, it will be set as empty.
-        if value.startswith('\x00'):
-            value = repr(value)[1:-1]
-
         value = unicode(value, 'utf-8', 'replace')
     else:
         try:


### PR DESCRIPTION
Now that we are removing non-pritable characters from the string, it doesn't make sense to have a special handling for strings starting with `\x00`.

Related https://github.com/viaforensics/viaextract-main/issues/1739#issuecomment-133359212

@jcollado although I think this is the correct fix (like I said on the original issue, if one needs binary transformation it should not be using the string one), if it is needed, we can try to identify binary strings and use the binary transformation instead.

More specifically, we can use a fuction like [is_binary](https://github.com/viaforensics/viacore/blob/master/viacore-gtk/viacore_gtk/file_inspector/file.py#L336) on viacore to test it and, if it is, we call [the binary transformation](https://github.com/viaforensics/viaextract-main/blob/develop/viaextract/ui/preview/__init__.py#L113) instead (it would mean porting that transformation to datagrid, although I don't know why we didn't do that before =P).

What do you think? Obviously, only if it is needed.